### PR TITLE
[HER-164] Add parametrized go to detection

### DIFF
--- a/src/cameras/map/marker/info/index.jsx
+++ b/src/cameras/map/marker/info/index.jsx
@@ -7,12 +7,13 @@ import { Latitude } from 'cameras/map/marker/info/latitude'
 import { Longitude } from 'cameras/map/marker/info/longitude'
 import { useStyles } from 'cameras/map/style'
 import { Item } from 'cameras/map/marker/item-props'
+import { useNavigation } from 'detections/table/hooks/use-navigation'
 
 export const Info = ({ item }) => <Box className={useStyles().infoWindowStyle}>
   <Id item={item} />
   <Latitude item={item} />
   <Longitude item={item} />
-  <Button> See more </Button>
+  <Button onClick={useNavigation(`/detections?cameraId=${item.id}`)}> See more </Button>
 </Box>
 
 Info.propTypes = { item: PropTypes.objectOf(Item).isRequired }


### PR DESCRIPTION
## Description
When clicking on the See more button on a camera’s tooltip, we should be redirected to the detections page, with the camera added to the filters.

## Related
[HER-164](https://nerds-interns.atlassian.net/jira/software/projects/HER/boards/1?selectedIssue=HER-164)