### PR TITLE
[HER-168] Fix spaces problem

### DIFF
--- a/src/detections/hooks/use-camera-filter.js
+++ b/src/detections/hooks/use-camera-filter.js
@@ -4,8 +4,9 @@ import { useIndex } from 'detections/hooks/use-index'
 
 export const useCameraFilter = () => {
   const link = useLocation()
-  const cameraId = useIndex()
+  const index = useIndex()
   const keys = link.search.split(/[?,&,=]/)
+  const cameraId = keys[index + 1].replace('%20', ' ')
 
-  return link.search && cameraId > 0 ? [keys[cameraId + 1]] : [null]
+  return link.search && index > 0 ? [cameraId] : [null]
 }


### PR DESCRIPTION
## Description
Fix the black spaces from the camera id that are replaced with `20%` when they are on the URL on the detection page when it is used for filters to query params.

## Related
[HER-168](https://nerds-interns.atlassian.net/jira/software/projects/HER/boards/1?selectedIssue=HER-168)